### PR TITLE
Checks the returned score as well as for a valid token.

### DIFF
--- a/GoogleReCaptcha.V3/GoogleReCaptchaValidator.cs
+++ b/GoogleReCaptcha.V3/GoogleReCaptchaValidator.cs
@@ -14,18 +14,24 @@ namespace GoogleReCaptcha.V3
         private readonly HttpClient _httpClient;
         private const string RemoteAddress = "https://www.google.com/recaptcha/api/siteverify";
         private string _secretKey;
+        private double _minimumScore;
 
         public GoogleReCaptchaValidator(HttpClient httpClient, IConfiguration configuration)
         {
             _httpClient = httpClient;
-
+            
             _secretKey = configuration["googleReCaptcha:SecretKey"];
+            _minimumScore = System.Convert.ToDouble(configuration["googleReCaptcha:MinimumScore"]);
         }
 
         public async Task<bool> IsCaptchaPassedAsync(string token)
         {
             dynamic response = await GetCaptchaResultDataAsync(token);
-            return response.success == "true";
+            if (response.success == "true")
+            {
+                return System.Convert.ToDouble(response.score) >= _minimumScore;
+            }
+            return false;
         }
 
         public async Task<JObject> GetCaptchaResultDataAsync(string token)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ When targeting 3.0 use package version 1.1.2
 Install the package https://www.nuget.org/packages/GoogleReCaptcha.V3/ using nuget
 Update your appsetting.json config file
 
-    "googleReCaptcha:SiteKey": "_YOUR_SITE_KEY",
+    "googleReCaptcha:SiteKey": "YOUR_SITE_KEY",
     "googleReCaptcha:SecretKey": "YOUR_SECRET_KEY"
+    "googleReCaptcha:SecretKey": "YOUR_MINIMUM_ACCEPTABLE_SCORE"
     
 You can get your keys here: https://www.google.com/recaptcha/admin
 

--- a/SampleWeb/Controllers/HomeController.cs
+++ b/SampleWeb/Controllers/HomeController.cs
@@ -35,6 +35,10 @@ namespace SampleWeb.Controllers
             {
                 ViewData["Message"] = "Success";
             }
+            else
+            {
+                ViewData["Message"] = "Failure";
+            }
             return View(collection);
         }
 

--- a/SampleWeb/appsettings.json
+++ b/SampleWeb/appsettings.json
@@ -1,6 +1,7 @@
 {
-  "googleReCaptcha:SiteKey": "_YOUR_SITE_KEY",
+  "googleReCaptcha:SiteKey": "YOUR_SITE_KEY",
   "googleReCaptcha:SecretKey": "YOUR_SECRET_KEY",
+  "googleReCaptcha:MinimumScore": 0.5,
 
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Currently your code only checks whether the request was a valid reCAPTCHA v3 token. You are not checking the score to see if it actually passed the check within the parameters you should have set. Without checking the score against a supplied minimum allowable score all valid tokens are allowed through even if the score points to the visitor being a bot.

This pull request addresses this major issue and adds a new googleReCaptcha:MinimumScore value to appsettings.json which should be set between 0.0 and 1.0 and uses this as the minimum score needed to pass the reCAPTCHA v3 test.